### PR TITLE
Add basic auth, i18n and docs

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 FORMUP
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,50 @@
 # FORMUP
+
+FORMUP est une application de gestion de formations développée avec React, TypeScript et Tailwind CSS.
+Elle a pour objectif de faciliter le suivi administratif et pédagogique des actions de formation tout en respectant les exigences de la certification **Qualiopi**.
+
+## Pré-requis
+
+- Node.js >= 18
+- npm
+
+## Installation
+
+```bash
+npm install
+```
+
+## Lancement en développement
+
+```bash
+npm run dev
+```
+
+## Construction pour la production
+
+```bash
+npm run build
+```
+
+## Aperçu des modules
+
+- **Dashboard** : vue d'ensemble des indicateurs.
+- **Sessions** : gestion des sessions de formation.
+- **Documents** : stockage et génération des documents réglementaires (feuilles d'émargement, conventions, attestations).
+- **Billing** : suivi de la facturation.
+- **ELearning** : accès aux contenus e-learning.
+- **CRM** : gestion de la relation client.
+- **Automation** : automatisation de tâches (rappels, relances).
+
+Chaque module sera connecté à un futur backend pour stocker les informations nécessaires au respect des critères Qualiopi : traçabilité des présences, évaluations, améliorations continues, etc.
+
+## Conformité Qualiopi
+
+L'application prévoit les fonctionnalités suivantes pour répondre aux exigences de la certification :
+
+1. Suivi des participants et enregistrement des présences.
+2. Collecte de la satisfaction et des évaluations à chaud/froid.
+3. Génération automatique des documents obligatoires.
+4. Historisation des actions correctives et d'amélioration continue.
+
+Cette base de code est encore en cours de construction et de nombreuses fonctionnalités restent à implémenter.

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
   "dependencies": {
     "lucide-react": "^0.344.0",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "i18next": "^23.10.1",
+    "react-i18next": "^13.2.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,9 +12,12 @@ import { Billing } from './components/Billing';
 import { Settings } from './components/Settings';
 import { ThemeProvider } from './contexts/ThemeContext';
 import { UserProvider } from './contexts/UserContext';
+import { AuthProvider, useAuth } from './contexts/AuthContext';
+import { Login } from './components/Login';
 
-function App() {
+function InnerApp() {
   const [activeTab, setActiveTab] = useState('dashboard');
+  const { token } = useAuth();
 
   const renderContent = () => {
     switch (activeTab) {
@@ -43,18 +46,27 @@ function App() {
     }
   };
 
+  if (!token) {
+    return <Login />;
+  }
+
+  return (
+    <UserProvider>
+      <div className="flex h-screen bg-gray-50 dark:bg-gray-900 transition-colors duration-300">
+        <Sidebar activeTab={activeTab} setActiveTab={setActiveTab} />
+        <main className="flex-1 overflow-hidden">
+          {renderContent()}
+        </main>
+      </div>
+    </UserProvider>
+  );
+}
+export default function App() {
   return (
     <ThemeProvider>
-      <UserProvider>
-        <div className="flex h-screen bg-gray-50 dark:bg-gray-900 transition-colors duration-300">
-          <Sidebar activeTab={activeTab} setActiveTab={setActiveTab} />
-          <main className="flex-1 overflow-hidden">
-            {renderContent()}
-          </main>
-        </div>
-      </UserProvider>
+      <AuthProvider>
+        <InnerApp />
+      </AuthProvider>
     </ThemeProvider>
   );
 }
-
-export default App;

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -1,0 +1,42 @@
+import React, { useState } from 'react';
+import { useAuth } from '../contexts/AuthContext';
+
+export const Login: React.FC = () => {
+  const { login } = useAuth();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await login(email, password);
+  };
+
+  return (
+    <div className="flex items-center justify-center h-screen bg-gray-100">
+      <form onSubmit={handleSubmit} className="bg-white p-6 rounded shadow w-80">
+        <h1 className="text-xl font-bold mb-4">Connexion</h1>
+        <div className="mb-4">
+          <label className="block mb-1 text-sm">Email</label>
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="w-full border rounded px-2 py-1"
+          />
+        </div>
+        <div className="mb-4">
+          <label className="block mb-1 text-sm">Mot de passe</label>
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="w-full border rounded px-2 py-1"
+          />
+        </div>
+        <button type="submit" className="w-full bg-blue-600 text-white py-2 rounded">
+          Se connecter
+        </button>
+      </form>
+    </div>
+  );
+};

--- a/src/components/Sessions.tsx
+++ b/src/components/Sessions.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { 
   Plus, 
   Search, 
@@ -15,78 +15,31 @@ import {
   XCircle,
   AlertCircle
 } from 'lucide-react';
+import { fetchSessions, Session } from '../services/api';
 
 export const Sessions: React.FC = () => {
   const [searchTerm, setSearchTerm] = useState('');
   const [statusFilter, setStatusFilter] = useState('all');
   const [typeFilter, setTypeFilter] = useState('all');
 
-  const sessions = [
-    {
-      id: 1,
-      title: 'Formation React Avancé',
-      description: 'Approfondissement des concepts React avec hooks, context et performance',
-      date: '2024-01-15',
-      time: '09:00-12:00',
-      duration: 180,
-      participants: 15,
-      maxParticipants: 20,
-      type: 'présentiel',
-      location: 'Salle A - Centre de formation',
-      formateur: 'Marie Dubois',
-      status: 'confirmed',
-      price: 450,
-      tags: ['React', 'JavaScript', 'Frontend']
-    },
-    {
-      id: 2,
-      title: 'Management d\'équipe',
-      description: 'Techniques de leadership et gestion d\'équipe moderne',
-      date: '2024-01-16',
-      time: '14:00-17:00',
-      duration: 180,
-      participants: 8,
-      maxParticipants: 12,
-      type: 'visio',
-      location: 'Zoom',
-      formateur: 'Jean Martin',
-      status: 'pending',
-      price: 350,
-      tags: ['Management', 'Leadership', 'RH']
-    },
-    {
-      id: 3,
-      title: 'Sécurité Informatique',
-      description: 'Bonnes pratiques de sécurité et protection des données',
-      date: '2024-01-17',
-      time: '10:00-16:00',
-      duration: 360,
-      participants: 20,
-      maxParticipants: 25,
-      type: 'hybride',
-      location: 'Salle B + Visio',
-      formateur: 'Sophie Laurent',
-      status: 'confirmed',
-      price: 650,
-      tags: ['Sécurité', 'RGPD', 'Cybersécurité']
-    },
-    {
-      id: 4,
-      title: 'Design Thinking',
-      description: 'Méthodologie d\'innovation centrée utilisateur',
-      date: '2024-01-18',
-      time: '09:00-17:00',
-      duration: 480,
-      participants: 12,
-      maxParticipants: 15,
-      type: 'présentiel',
-      location: 'Salle créative',
-      formateur: 'Thomas Petit',
-      status: 'draft',
-      price: 750,
-      tags: ['Design', 'Innovation', 'UX']
-    }
-  ];
+  const [sessions, setSessions] = useState<Session[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetchSessions()
+      .then((data) => setSessions(data))
+      .catch(() => setError('Erreur lors du chargement'))
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) {
+    return <div className="p-6">Chargement...</div>;
+  }
+
+  if (error) {
+    return <div className="p-6 text-red-500">{error}</div>;
+  }
 
   const filteredSessions = sessions.filter(session => {
     const matchesSearch = session.title.toLowerCase().includes(searchTerm.toLowerCase()) ||

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -17,6 +17,7 @@ import {
 } from 'lucide-react';
 import { useTheme } from '../contexts/ThemeContext';
 import { useUser } from '../contexts/UserContext';
+import { useTranslation } from 'react-i18next';
 
 interface SidebarProps {
   activeTab: string;
@@ -26,18 +27,19 @@ interface SidebarProps {
 export const Sidebar: React.FC<SidebarProps> = ({ activeTab, setActiveTab }) => {
   const { darkMode, toggleDarkMode } = useTheme();
   const { user, permissions } = useUser();
+  const { t } = useTranslation();
 
   const menuItems = [
-    { id: 'dashboard', label: 'Tableau de bord', icon: Home, permission: 'all' },
-    { id: 'calendar', label: 'Calendrier', icon: Calendar, permission: 'calendar' },
-    { id: 'sessions', label: 'Sessions', icon: Users, permission: 'sessions' },
-    { id: 'documents', label: 'Documents', icon: FileText, permission: 'documents' },
-    { id: 'videoconference', label: 'Visioformation', icon: Video, permission: 'videoconference' },
-    { id: 'elearning', label: 'E-learning', icon: BookOpen, permission: 'elearning' },
-    { id: 'crm', label: 'CRM', icon: UserCheck, permission: 'crm' },
-    { id: 'automation', label: 'Automatisation', icon: Zap, permission: 'automation' },
-    { id: 'billing', label: 'Facturation', icon: CreditCard, permission: 'billing' },
-    { id: 'settings', label: 'Paramètres', icon: Settings, permission: 'settings' },
+    { id: 'dashboard', key: 'sidebar.dashboard', icon: Home, permission: 'all' },
+    { id: 'calendar', key: 'sidebar.calendar', icon: Calendar, permission: 'calendar' },
+    { id: 'sessions', key: 'sidebar.sessions', icon: Users, permission: 'sessions' },
+    { id: 'documents', key: 'sidebar.documents', icon: FileText, permission: 'documents' },
+    { id: 'videoconference', key: 'sidebar.videoconference', icon: Video, permission: 'videoconference' },
+    { id: 'elearning', key: 'sidebar.elearning', icon: BookOpen, permission: 'elearning' },
+    { id: 'crm', key: 'sidebar.crm', icon: UserCheck, permission: 'crm' },
+    { id: 'automation', key: 'sidebar.automation', icon: Zap, permission: 'automation' },
+    { id: 'billing', key: 'sidebar.billing', icon: CreditCard, permission: 'billing' },
+    { id: 'settings', key: 'sidebar.settings', icon: Settings, permission: 'settings' },
   ];
 
   const hasPermission = (permission: string) => {
@@ -110,7 +112,7 @@ export const Sidebar: React.FC<SidebarProps> = ({ activeTab, setActiveTab }) => 
               }`}
             >
               <Icon className={`w-5 h-5 ${isActive ? 'text-blue-600 dark:text-blue-400' : 'text-gray-400'}`} />
-              <span className="font-medium">{item.label}</span>
+              <span className="font-medium">{t(item.key)}</span>
             </button>
           );
         })}

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,0 +1,37 @@
+import React, { createContext, useContext, useState } from 'react';
+
+interface AuthContextType {
+  token: string | null;
+  login: (email: string, password: string) => Promise<void>;
+  logout: () => void;
+}
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+export const useAuth = () => {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return context;
+};
+
+export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [token, setToken] = useState<string | null>(null);
+
+  const login = async (email: string, password: string) => {
+    // TODO: call authentication API and retrieve a token
+    // For now we simulate a successful login
+    setToken('mock-token');
+  };
+
+  const logout = () => {
+    setToken(null);
+  };
+
+  return (
+    <AuthContext.Provider value={{ token, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,0 +1,17 @@
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
+
+import fr from './locales/fr/translation.json';
+import en from './locales/en/translation.json';
+
+i18n.use(initReactI18next).init({
+  resources: {
+    fr: { translation: fr },
+    en: { translation: en },
+  },
+  lng: 'fr',
+  fallbackLng: 'fr',
+  interpolation: { escapeValue: false },
+});
+
+export default i18n;

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1,0 +1,14 @@
+{
+  "sidebar": {
+    "dashboard": "Dashboard",
+    "calendar": "Calendar",
+    "sessions": "Sessions",
+    "documents": "Documents",
+    "videoconference": "Video meetings",
+    "elearning": "E-learning",
+    "crm": "CRM",
+    "automation": "Automation",
+    "billing": "Billing",
+    "settings": "Settings"
+  }
+}

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -1,0 +1,14 @@
+{
+  "sidebar": {
+    "dashboard": "Tableau de bord",
+    "calendar": "Calendrier",
+    "sessions": "Sessions",
+    "documents": "Documents",
+    "videoconference": "Visioformation",
+    "elearning": "E-learning",
+    "crm": "CRM",
+    "automation": "Automatisation",
+    "billing": "Facturation",
+    "settings": "Paramètres"
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
 import './index.css';
+import './i18n';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,0 +1,39 @@
+export interface Session {
+  id: number;
+  title: string;
+  description: string;
+  date: string;
+  time: string;
+  duration: number;
+  participants: number;
+  maxParticipants: number;
+  type: string;
+  location: string;
+  formateur: string;
+  status: string;
+  price: number;
+  tags: string[];
+}
+
+export async function fetchSessions(): Promise<Session[]> {
+  // In a real application, this would call the backend API.
+  // Here we return a mocked response to illustrate the data flow.
+  return Promise.resolve([
+    {
+      id: 1,
+      title: 'Formation React Avancé',
+      description: 'Approfondissement des concepts React avec hooks, context et performance',
+      date: '2024-01-15',
+      time: '09:00-12:00',
+      duration: 180,
+      participants: 15,
+      maxParticipants: 20,
+      type: 'présentiel',
+      location: 'Salle A - Centre de formation',
+      formateur: 'Marie Dubois',
+      status: 'confirmed',
+      price: 450,
+      tags: ['React', 'JavaScript', 'Frontend'],
+    },
+  ]);
+}


### PR DESCRIPTION
## Summary
- expand README with setup steps and Qualiopi overview
- add MIT license file
- add authentication context with login screen
- create mocked API service and use it in sessions page
- integrate i18next with French and English translations
- show translated labels in Sidebar

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_6868a40090e0832cb98858a0116aac6b